### PR TITLE
🔧 Add Go module cache access to sandbox

### DIFF
--- a/claude-code-sandbox.sb
+++ b/claude-code-sandbox.sb
@@ -198,6 +198,7 @@
     (subpath (string-append (param "HOME") "/.gem"))      ;; Ruby gems
     (subpath (string-append (param "HOME") "/.cache"))    ;; General cache
     (subpath (string-append (param "HOME") "/.bundle"))   ;; Bundler cache
+    (subpath (string-append (param "HOME") "/go"))        ;; Go
     
     ;; Claude configuration
     (subpath (string-append (param "HOME") "/.claude"))  ;; Claude config directory
@@ -286,6 +287,7 @@
     (subpath (string-append (param "HOME") "/.bundle"))       ;; Bundler cache
     (subpath (string-append (param "HOME") "/.cargo/registry")) ;; Cargo registry
     (subpath (string-append (param "HOME") "/.gem"))          ;; Ruby gems
+    (subpath (string-append (param "HOME") "/go/pkg/mod/cache"))          ;; Go Cache
     
     ;; Audit log location (project-specific)
     (subpath (param "AUDIT_LOG_PATH"))


### PR DESCRIPTION
## Summary

Enable Go development workflows by providing sandbox access to Go module cache directories.

## Changes
- Added read access to `~/go` directory
- Added read/write access to `~/go/pkg/mod/cache` for Go module caching

## Context
This change allows Go developers to work with modules and dependencies within the Claude Code sandbox environment, enabling commands like `go mod download` and `go get` to function properly.

## Testing
- Go module commands now work within the sandbox
- Module cache is properly accessible for reading and writing

🤖 Generated with Claude Code