### PR TITLE
✨ Add Crawl4AI integration to meta-agent

### DIFF
--- a/claude-code-sandbox.sb
+++ b/claude-code-sandbox.sb
@@ -287,6 +287,7 @@
     (subpath (string-append (param "HOME") "/.bundle"))       ;; Bundler cache
     (subpath (string-append (param "HOME") "/.cargo/registry")) ;; Cargo registry
     (subpath (string-append (param "HOME") "/.gem"))          ;; Ruby gems
+    (subpath (string-append (param "HOME") "/Library/Caches/go-build"))
     (subpath (string-append (param "HOME") "/go/pkg/mod/cache"))          ;; Go Cache
     
     ;; Audit log location (project-specific)

--- a/claude-code/agents/meta-agent.md
+++ b/claude-code/agents/meta-agent.md
@@ -12,7 +12,7 @@ Your sole purpose is to act as an expert agent architect. You will take a user's
 
 ## Instructions
 
-**0. Get up to date documentation:** Scrape the Claude Code sub-agent feature to get the latest documentation: 
+**0. Get up to date documentation:** Scrape the Claude Code sub-agent feature to get the latest documentation (use the c4ai mcp md call if avaialble): 
     - `https://docs.anthropic.com/en/docs/claude-code/sub-agents` - Sub-agent feature
     - `https://docs.anthropic.com/en/docs/claude-code/settings#tools-available-to-claude` - Available tools
 **1. Analyze Input:** Carefully analyze the user's prompt to understand the new agent's purpose, primary tasks, and domain.
@@ -24,7 +24,7 @@ Your sole purpose is to act as an expert agent architect. You will take a user's
 **7. Provide a numbered list** or checklist of actions for the agent to follow when invoked.
 **8. Incorporate best practices** relevant to its specific domain.
 **9. Define output structure:** If applicable, define the structure of the agent's final output or feedback.
-**10. Assemble and Output:** Combine all the generated components into a single Markdown file. Adhere strictly to the `Output Format` below. Your final response should ONLY be the content of the new agent file. Write the file to the `.claude/agents/<generated-agent-name>.md` directory.
+**10. Assemble and Output:** Combine all the generated components into a single Markdown file. Adhere strictly to the `Output Format` below. Your final response should ONLY be the content of the new agent file. Write the file to the `.claude/agents/<generated-agent-name>.md` directory, unless specified to do otherwise.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
- Integrates Crawl4AI capabilities into the meta-agent
- Updates sandbox security profile with Go module cache access

## Changes
- Added Crawl4AI integration to meta-agent
- Updated sandbox permissions for Go module caching

## Test Plan
- [ ] Test meta-agent with Crawl4AI features
- [ ] Verify Go module cache access works correctly
- [ ] Validate sandbox security remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)